### PR TITLE
Feature/dockerize

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /config.py
 /instance
 .env
+.venv

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 *.pyc
-/config.py
+/coloringbook/config.py
 /instance
 .env
 .venv

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 *.pyc
 /coloringbook/config.py
 /instance
-.env
 .venv
+.env

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.pyc
 /config.py
 /instance
+.env

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,5 +17,5 @@ COPY CONFIG.py coloringbook/CONFIG.py
 EXPOSE 5000
 
 # Start server
-CMD ["python",  "manage.py",  "-c", "CONFIG.py", "runserver", "-dr", "--host", "0.0.0.0"]
+CMD python manage.py -A -c CONFIG.py db upgrade && python manage.py -c CONFIG.py runserver -dr --host 0.0.0.0
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,8 @@
 # syntax=docker/dockerfile:1
 FROM python:2.7.9
 
-# Install GIT
-RUN apt install -y git
-
-# Clone repository
-RUN git clone https://github.com/UUDigitalHumanitieslab/coloringbook.git
+# Copy source files
+COPY . /coloringbook
 
 # Change working directory
 WORKDIR /coloringbook
@@ -20,4 +17,5 @@ COPY CONFIG.py coloringbook/CONFIG.py
 EXPOSE 5000
 
 # Start server
-CMD ["python",  "manage.py",  "-c", "CONFIG.py", "runserver", "-d"]
+CMD ["python",  "manage.py",  "-c", "CONFIG.py", "runserver", "-dr", "--host", "0.0.0.0"]
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,5 +14,4 @@ RUN pip install -r requirements.txt
 EXPOSE 5000
 
 # Start server
-CMD python manage.py -A -c CONFIG.py db upgrade && python manage.py -c CONFIG.py runserver -dr --host 0.0.0.0
-
+CMD python manage.py -A -c config.py db upgrade && python manage.py -c config.py runserver -dr --host 0.0.0.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+# syntax=docker/dockerfile:1
+FROM python:2.7.9
+
+# Install GIT
+RUN apt install -y git
+
+# Clone repository
+RUN git clone https://github.com/UUDigitalHumanitieslab/coloringbook.git
+
+# Change working directory
+WORKDIR /coloringbook
+
+# Install dependencies
+RUN pip install -r requirements.txt
+
+# Copy the config file
+COPY CONFIG.py coloringbook/CONFIG.py
+
+# Expose port
+EXPOSE 5000
+
+# Start server
+CMD ["python",  "manage.py",  "-c", "CONFIG.py", "runserver", "-d"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,5 +13,8 @@ RUN pip install -r requirements.txt
 # Expose port
 EXPOSE 5000
 
-# Start server
-CMD python manage.py -A -c config.py db upgrade && python manage.py -c config.py runserver -dr --host 0.0.0.0
+# Set build-time variables
+ARG DEVELOPMENT=0
+
+# Start server. If DEVELOPMENT is set with value 1, then the flag -dr is added.
+CMD if [ "$DEVELOPMENT" = "1" ]; then python manage.py -A -c config.py db upgrade && python manage.py -c config.py runserver --host 0.0.0.0 -dr; else python manage.py -A -c config.py db upgrade && python manage.py -c config.py runserver --host 0.0.0.0; fi

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,9 +10,6 @@ WORKDIR /coloringbook
 # Install dependencies
 RUN pip install -r requirements.txt
 
-# Copy the config file
-COPY CONFIG.py coloringbook/CONFIG.py
-
 # Expose port
 EXPOSE 5000
 

--- a/Readme.md
+++ b/Readme.md
@@ -43,7 +43,7 @@ Docker needs a file called `.env` to be present in the same folder as `docker-co
     MYSQL_DB=abcdefg
     MYSQL_ROOT_PASSWORD=abcdefg
 
-Secondly, a file `config.py` should be created in the `colouringbook` package folder with minimally the following contents.
+Secondly, a file `config.py` should be created in the `coloringbook` package folder with minimally the following contents.
 
     SQLALCHEMY_DATABASE_URI = 'mysql://coloringbook:myawesomepassword@localhost/coloringbook'
     SECRET_KEY = '12345678901234567890'

--- a/Readme.md
+++ b/Readme.md
@@ -32,35 +32,38 @@ Researchers can compose their own surveys with custom images and sounds. The sur
 
 On the client side, test subjects just need to run a HTML5 capable browser.
 
-On the server side, Coloring Book is a WSGI application, which means that it will run on any webserver that supports standard Python web applications. Apart from a WSGI-enabled webserver, install the dependencies using `pip install -r requirements.txt` or preferably `pip-sync` from the pip-tools package.
+Coloring Book is deployed using Docker Compose. The application needs two configuration files. 
 
-Assuming you opt to use MySQL (or anything other than SQLite), you need to create an empty database with pre-configured access rights for the Coloring Book application to use. For example by entering the following commands while running `mysql` as root user:
+Docker needs a file called `.env` to be present in the same folder as `docker-compose.yml`, containing at least the following settings.
 
-    create database coloringbook;
-    grant all privileges on coloringbook.* to 'coloringbook'@'localhost' identified by 'myawesomepassword';
+    MYSQL_HOST=abcdefg
+    MYSQL_PORT=1234
+    MYSQL_USER=abcdefg
+    MYSQL_PASSWORD=abcdefg
+    MYSQL_DB=abcdefg
+    MYSQL_ROOT_PASSWORD=abcdefg
 
-**Note** that you should not use the password quoted above. You can choose the name of the database and the name of the user freely as well.
-
-Coloring Book obtains the necessary information to connect to the database from a user-provided configuration file. This is what the file contents should minimally look like:
+Secondly, a file `config.py` should be created in the `colouringbook` package folder with minimally the following contents.
 
     SQLALCHEMY_DATABASE_URI = 'mysql://coloringbook:myawesomepassword@localhost/coloringbook'
     SECRET_KEY = '12345678901234567890'
 
-This file should be saved with a `.py` extension. Your WSGI startup module should pass the absolute path to this file as the first argument to `coloringbook.create_app`.
+With these files present, running `docker compose up --build` in the root directory of the project will start two containers.
 
-Before running the application, you need to run the database migrations. Use the following command:
+- the Coloring Book web server proper;
+- a MySQL database (MySQL).
+
+Docker should automatically create the database and run the available migrations. To run migrations manually, run
 
     python manage.py -A -c CONFIG db upgrade
 
 where `CONFIG` is the path to your local configuration file, either relative to the `coloringbook` package or absolute. Replace the last part of the command by `db -?` to get a summary of possible database manipulations.
 
+The project source files are automatically mounted to the local file system, so any changes made to the application are applied immediately, and the server is reloaded ('live reload').
+
 The application does not take care of authentication or authorization. You should configure this directly on the webserver by restricting access to `/admin/`, for example using LDAP.
 
-For development, you may run a local test server by invoking
-
-    python manage.py -c CONFIG runserver -dr
-
-The `-dr` flags switch on debugging settings and autoreloading. The application will run on `localhost:5000` by default, but you can change this by passing appropriate flags to the command. See the `-?` flag for details.
+By default, the application will run on `localhost:5000`, but this is customisable in the `Dockerfile`.
 
 
 ## Development

--- a/Readme.md
+++ b/Readme.md
@@ -59,7 +59,7 @@ Docker should automatically create the database and run the available migrations
 
 where `CONFIG` is the path to your local configuration file, either relative to the `coloringbook` package or absolute. Replace the last part of the command by `db -?` to get a summary of possible database manipulations.
 
-The project source files are automatically mounted to the local file system, so any changes made to the application are applied immediately, and the server is reloaded ('live reload').
+The project source files are automatically mounted to the local file system. In development mode (see below), any changes made to the application are applied immediately, and the server is reloaded ('live reload').
 
 The application does not take care of authentication or authorization. You should configure this directly on the webserver by restricting access to `/admin/`, for example using LDAP.
 
@@ -69,6 +69,14 @@ By default, the application will run on `localhost:5000`, but this is customisab
 ## Development
 
 An overview of the database layout is given in `Database.svg`. For the complete specification, refer to `coloringbook/models.py`. Anything in `admin` subfolders is specific to the admin interface. Everything else in the `coloringbook` package is involved in delivering surveys to subjects and receiving data from them. Run `python test.py` for doctest-based testing. Motivations are documented throughout the code in comments; with some referencing to documentation for Flask, SQLAlchemy and jQuery, you should be able to find your way.
+
+It is possible to run the server in the development mode by adding the following line to `.env`. 
+
+```
+DEVELOPMENT=1
+``` 
+
+This will print debug messages in the container logs and enable automatic reloading when the source files are changed.
 
 
 ## Server maintenance

--- a/coloringbook/admin/utilities.py
+++ b/coloringbook/admin/utilities.py
@@ -1,3 +1,5 @@
+# coding=utf-8
+
 # (c) 2014-2023 Research Software Lab, Centre for Digital Humanities, Utrecht University
 # Licensed under the EUPL-1.2 or later. You may obtain a copy of the license at
 # https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3'
+version: '3.9'
 services:
   db:
     image: mysql:5.7
@@ -11,6 +11,10 @@ services:
       MYSQL_PASSWORD: colmybook
     ports:
       - "3307:3306"
+    healthcheck:
+      test: ["CMD", "mysqladmin" ,"ping", "-p${MYSQL_PASSWORD}"]
+      timeout: 20s
+      retries: 10
 
   app:
     build:
@@ -19,9 +23,8 @@ services:
     ports:
       - 5000:5000
     depends_on:
-      - db
-    links:
-      - db
+      db:
+        condition: service_healthy
     environment:
       - MYSQL_HOST=db
       - MYSQL_PORT=3306

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,9 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
-    env_file: .env  
+      args:
+        - DEVELOPMENT=${DEVELOPMENT}
+    env_file: .env
     ports:
       - 5000:5000
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,8 @@ services:
       test: ["CMD", "mysqladmin" ,"ping", "-p${MYSQL_PASSWORD}"]
       timeout: 20s
       retries: 10
+    volumes:
+      - sql-db:/var/lib/mysql
 
   app:
     build:
@@ -31,3 +33,9 @@ services:
       - MYSQL_USER=coloringbook
       - MYSQL_PASSWORD=colmybook
       - MYSQL_DB=coloringbook
+    volumes:
+      - .:/coloringbook:rw
+
+volumes:
+  sql-db:
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,13 +2,14 @@ version: '3.9'
 services:
   db:
     image: mysql:5.7
+    env_file: .env
     restart: always
     command: --default-authentication-plugin=mysql_native_password
     environment:
-      MYSQL_DATABASE: coloringbook
-      MYSQL_ROOT_PASSWORD: rootpw
-      MYSQL_USER: coloringbook
-      MYSQL_PASSWORD: colmybook
+      MYSQL_DATABASE: ${MYSQL_DB}
+      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
+      MYSQL_USER: ${MYSQL_USER}
+      MYSQL_PASSWORD: ${MYSQL_PASSWORD}
     ports:
       - "3307:3306"
     healthcheck:
@@ -22,17 +23,19 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
+    env_file: .env  
     ports:
       - 5000:5000
     depends_on:
       db:
         condition: service_healthy
     environment:
-      - MYSQL_HOST=db
-      - MYSQL_PORT=3306
-      - MYSQL_USER=coloringbook
-      - MYSQL_PASSWORD=colmybook
-      - MYSQL_DB=coloringbook
+      - MYSQL_DB=${MYSQL_DB}
+      - MYSQL_HOST=${MYSQL_HOST}
+      - MYSQL_PORT=${MYSQL_PORT}
+      - MYSQL_USER=${MYSQL_USER}
+      - MYSQL_PASSWORD=${MYSQL_PASSWORD}
+      - MYSQL_ROOT_PASSWORD=${MYSQL_ROOT_PASSWORD}
     volumes:
       - .:/coloringbook:rw
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,30 @@
+version: '3'
+services:
+  db:
+    image: mysql:5.7
+    restart: always
+    command: --default-authentication-plugin=mysql_native_password
+    environment:
+      MYSQL_DATABASE: coloringbook
+      MYSQL_ROOT_PASSWORD: rootpw
+      MYSQL_USER: coloringbook
+      MYSQL_PASSWORD: colmybook
+    ports:
+      - "3307:3306"
+
+  app:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    ports:
+      - 5000:5000
+    depends_on:
+      - db
+    links:
+      - db
+    environment:
+      - MYSQL_HOST=db
+      - MYSQL_PORT=3306
+      - MYSQL_USER=coloringbook
+      - MYSQL_PASSWORD=colmybook
+      - MYSQL_DB=coloringbook


### PR DESCRIPTION
This PR sets up ColoringBook to run inside a docker-compose network. It contains cherry-picked commits from https://github.com/UUDigitalHumanitieslab/coloringbook/pull/29 and makes changes based on the commentary on that PR.

In addition, the server can now be run in prod or dev mode by adding/removing `DEVELOPMENT=1` to/from `.env`.