### PR TITLE
Fix: update character limit on Page.name

### DIFF
--- a/coloringbook/admin/utilities.py
+++ b/coloringbook/admin/utilities.py
@@ -9,6 +9,7 @@
 """
 
 import StringIO, csv, datetime as dt
+
 from flask import make_response, request
 from coloringbook.models import PAGE_NAME_CHAR_LIMIT
 
@@ -112,6 +113,7 @@ def filters_from_request(self):
             applicables.append((flt, value))
 
     return applicables
+
 
 def get_page_copy_name(old_page_name):
     """

--- a/coloringbook/admin/utilities.py
+++ b/coloringbook/admin/utilities.py
@@ -9,8 +9,8 @@
 """
 
 import StringIO, csv, datetime as dt
-
 from flask import make_response, request
+from coloringbook.models import PAGE_NAME_CHAR_LIMIT
 
 
 def maybe_utf8(value):
@@ -112,3 +112,24 @@ def filters_from_request(self):
             applicables.append((flt, value))
 
     return applicables
+
+def get_page_copy_name(old_page_name):
+    """
+    Returns the name for a duplicated page, with ' (copy)' appended to the original name, as long as the resulting name is within the character limit.
+
+    >>> from coloringbook.admin.utilities import get_page_copy_name
+    >>> get_page_copy_name('A page')
+    'A page (copy)'
+
+    >>> get_page_copy_name('A page whose name is just ninety-eight characters long, so that copy will not be added at its end.')
+    'A page whose name is just ninety-eight characters long, so that copy will not be added at its end.'
+
+    """
+    copy_suffix = " (copy)"
+
+    new_page_name = old_page_name + copy_suffix
+
+    if len(new_page_name) > PAGE_NAME_CHAR_LIMIT:
+        return old_page_name
+
+    return new_page_name

--- a/coloringbook/admin/views.py
+++ b/coloringbook/admin/views.py
@@ -23,7 +23,7 @@ from flask.ext.admin.actions import action
 
 from ..models import *
 
-from .utilities import csvdownload
+from .utilities import csvdownload, get_page_copy_name
 from .forms import Select2MultipleField, FileNameLength
 
 
@@ -396,7 +396,7 @@ class PageView(ModelView):
         for page_id in page_ids:
             page = Page.query.get(page_id)
             new_page = Page(
-                name=page.name + ' (copy)',
+                name=get_page_copy_name(page.name),
                 drawing=page.drawing,
                 language=page.language,
                 text=page.text,

--- a/coloringbook/models.py
+++ b/coloringbook/models.py
@@ -14,6 +14,8 @@ from sqlalchemy.ext.associationproxy import association_proxy
 from sqlalchemy.ext.declarative import declared_attr
 
 
+PAGE_NAME_CHAR_LIMIT = 100  # maximum length of a Page name
+
 def TableArgsMeta(parent_class, table_args):
     """
         Metaclass generator to set global defaults for __table_args__.
@@ -175,7 +177,7 @@ class Page(db.Model):
     """ Combination of a sentence and a Drawing. """
 
     id = db.Column(db.Integer, primary_key=True)
-    name = db.Column(db.String(30), nullable=False)
+    name = db.Column(db.String(PAGE_NAME_CHAR_LIMIT), nullable=False)
     language_id = db.Column(db.Integer, db.ForeignKey('language.id'))
     text = db.Column(db.String(200))  # sentence
     sound_id = db.Column(db.Integer, db.ForeignKey('sound.id'))

--- a/migrations/versions/b888de398f59_update_page_name_char_limit.py
+++ b/migrations/versions/b888de398f59_update_page_name_char_limit.py
@@ -1,0 +1,28 @@
+"""update page name char limit
+
+Revision ID: b888de398f59
+Revises: 03a51cc0b8b6
+Create Date: 2024-06-21 11:33:12.251000
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = 'b888de398f59'
+down_revision = '03a51cc0b8b6'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.alter_column('page', 'name',
+                    existing_type=sa.String(length=30),
+                    type_=sa.String(length=100),
+                    existing_nullable=False)
+
+
+def downgrade():
+    op.alter_column('page', 'name',
+                    existing_type=sa.String(length=100),
+                    type_=sa.String(length=30),
+                    existing_nullable=False)


### PR DESCRIPTION
This PR fixes a bug that occurs when duplicating a page.

The duplication logic appends ` (copy)` to the name of the copied Page, but this often surpasses the fixed character limit (30 chars) for this field, leading to a 500 status code.

After consulting the researcher, it was agreed that the character limit be increased to 100 characters. For names of 93-100 characters, ` (copy)` is not to be added.