### PR TITLE
Feature/duplicate surveys

### DIFF
--- a/coloringbook/admin/utilities.py
+++ b/coloringbook/admin/utilities.py
@@ -13,6 +13,8 @@ import StringIO, csv, datetime as dt
 from flask import make_response, request
 
 
+COPY_PREFIX = 'Copy of '
+
 def maybe_utf8(value):
     """
         Returns UTF-8 encoded byte strings for unicode strings.
@@ -124,18 +126,13 @@ def get_copied_name(old_name, limit):
     :param limit: The maximum number of characters allowed for the new name.
 
     >>> from coloringbook.admin.utilities import get_copied_name
-    >>> get_copied_name('A page', 100)
-    'A page_copy)'
+    >>> get_copied_name('a page', 100)
+    'Copy of a page'
 
-    >>> get_copied_name('A page whose name is just ninety-eight characters long, so that copy will not be added at its end.', 100)
-    'A page whose name is just ninety-eight characters long, so that copy will not be added at its end.'
+    >>> get_copied_name('a page whose name is exactly ninety-five characters long, so that it will have to be truncated.', 100)
+    'Copy of a page whose name is exactly ninety-five characters long, so that it will have to be truncat'
 
     """
-    copy_suffix = "_copy"
 
-    new_name = old_name + copy_suffix
-
-    if len(new_name) > limit:
-        return old_name
-
-    return new_name
+    new_name = COPY_PREFIX + old_name
+    return new_name[:limit]

--- a/coloringbook/admin/utilities.py
+++ b/coloringbook/admin/utilities.py
@@ -116,14 +116,18 @@ def filters_from_request(self):
 
 def get_copied_name(old_name, limit):
     """
-    Returns the name for a duplicated page or survey, with '_copy' appended to the original name, as long as the resulting name is within the provided character limit.
+    Returns the name for a duplicated page or survey, with a suffix appended to
+    the original name to indicate that it is a copy. This only works as long as
+    the resulting name is within the provided character limit.
+
+    :param old_name: The original name of the page or survey.
+    :param limit: The maximum number of characters allowed for the new name.
 
     >>> from coloringbook.admin.utilities import get_copied_name
-    >>> from coloringbook.models import PAGE_NAME_CHAR_LIMIT
-    >>> get_copied_name('A page', PAGE_NAME_CHAR_LIMIT)
+    >>> get_copied_name('A page', 100)
     'A page_copy)'
 
-    >>> get_copied_name('A page whose name is just ninety-eight characters long, so that copy will not be added at its end.', PAGE_NAME_CHAR_LIMIT)
+    >>> get_copied_name('A page whose name is just ninety-eight characters long, so that copy will not be added at its end.', 100)
     'A page whose name is just ninety-eight characters long, so that copy will not be added at its end.'
 
     """

--- a/coloringbook/admin/utilities.py
+++ b/coloringbook/admin/utilities.py
@@ -11,7 +11,6 @@
 import StringIO, csv, datetime as dt
 
 from flask import make_response, request
-from coloringbook.models import PAGE_NAME_CHAR_LIMIT
 
 
 def maybe_utf8(value):
@@ -115,23 +114,24 @@ def filters_from_request(self):
     return applicables
 
 
-def get_page_copy_name(old_page_name):
+def get_copied_name(old_name, limit):
     """
-    Returns the name for a duplicated page, with ' (copy)' appended to the original name, as long as the resulting name is within the character limit.
+    Returns the name for a duplicated page or survey, with '_copy' appended to the original name, as long as the resulting name is within the provided character limit.
 
-    >>> from coloringbook.admin.utilities import get_page_copy_name
-    >>> get_page_copy_name('A page')
-    'A page (copy)'
+    >>> from coloringbook.admin.utilities import get_copied_name
+    >>> from coloringbook.models import PAGE_NAME_CHAR_LIMIT
+    >>> get_copied_name('A page', PAGE_NAME_CHAR_LIMIT)
+    'A page_copy)'
 
-    >>> get_page_copy_name('A page whose name is just ninety-eight characters long, so that copy will not be added at its end.')
+    >>> get_copied_name('A page whose name is just ninety-eight characters long, so that copy will not be added at its end.', PAGE_NAME_CHAR_LIMIT)
     'A page whose name is just ninety-eight characters long, so that copy will not be added at its end.'
 
     """
-    copy_suffix = " (copy)"
+    copy_suffix = "_copy"
 
-    new_page_name = old_page_name + copy_suffix
+    new_name = old_name + copy_suffix
 
-    if len(new_page_name) > PAGE_NAME_CHAR_LIMIT:
-        return old_page_name
+    if len(new_name) > limit:
+        return old_name
 
-    return new_page_name
+    return new_name

--- a/coloringbook/admin/views.py
+++ b/coloringbook/admin/views.py
@@ -326,7 +326,7 @@ class SurveyView(ModelView):
         'email_address': 'Used to send a notification when a survey is completed and uploaded.',
     }
 
-    @action('duplicate', 'Duplicate', 'Are you sure you want to duplicate the selected surveys?')
+    @action('duplicate', 'Duplicate')
     def duplicate_surveys(self, survey_ids):
         successful = []
         failed = []
@@ -445,7 +445,7 @@ class PageView(ModelView):
         rules.Macro('drawing.edit_expectations'),
     )
 
-    @action('duplicate', 'Duplicate', 'Are you sure you want to duplicate the selected pages?')
+    @action('duplicate', 'Duplicate')
     def duplicate_pages(self, page_ids):
         for page_id in page_ids:
             page = Page.query.get(page_id)

--- a/coloringbook/models.py
+++ b/coloringbook/models.py
@@ -15,6 +15,7 @@ from sqlalchemy.ext.declarative import declared_attr
 
 
 PAGE_NAME_CHAR_LIMIT = 100  # maximum length of a Page name
+SURVEY_NAME_CHAR_LIMIT = 100 # maximum length of a Survey name
 
 def TableArgsMeta(parent_class, table_args):
     """
@@ -334,7 +335,7 @@ class Survey(db.Model):
     """ Prepared series of Pages that is presented to Subjects. """
 
     id = db.Column(db.Integer, primary_key=True)
-    name = db.Column(db.String(40), nullable=False, unique=True)
+    name = db.Column(db.String(SURVEY_NAME_CHAR_LIMIT), nullable=False, unique=True)
     language_id = db.Column(db.Integer, db.ForeignKey('language.id'))
     begin = db.Column(db.DateTime)
     end = db.Column(db.DateTime)

--- a/migrations/versions/f94547b88580_increase_survey_name_character_limit.py
+++ b/migrations/versions/f94547b88580_increase_survey_name_character_limit.py
@@ -1,0 +1,28 @@
+"""Increase Survey name character limit
+
+Revision ID: f94547b88580
+Revises: b888de398f59
+Create Date: 2024-06-27 13:27:52.743000
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = 'f94547b88580'
+down_revision = 'b888de398f59'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.alter_column('survey', 'name',
+                    existing_type=sa.String(length=40),
+                    type_=sa.String(length=100),
+                    existing_nullable=False)
+
+
+def downgrade():
+    op.alter_column('survey', 'name',
+                    existing_type=sa.String(length=100),
+                    type_=sa.String(length=40),
+                    existing_nullable=False)


### PR DESCRIPTION
Resolves #45 

Copies a lot of the logic implemented in #40, including an increase of character limit to 100 characters.

The 'copy suffix' added to the name of the duplicated entity has been changed from ` (copy)` to `_copy`, to ensure that it can be used in an URL.

The only complication here is that Survey names must be unique. I've played around with the idea of adding an incrementing number, but that would not be robust if the Survey name already ends in a number and it may cause confusion. In the end I decided to simply inform the user of which surveys were successfully duplicated and which were not.