### PR TITLE
Bugfix/failing redis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,5 @@
 .venv
 .env
 
-# Gunicorn logs
-access_log
-error_log
+# Log files
+logs/*

--- a/coloringbook/__init__.py
+++ b/coloringbook/__init__.py
@@ -38,6 +38,7 @@
     potentially be served in production.
 """
 
+from logging.config import dictConfig
 from os import environ
 from flask import Flask
 from flask_migrate import Migrate
@@ -83,6 +84,24 @@ def create_app(config, disable_admin=False, create_db=False, use_test_db=False, 
         The Flask application.
 
     """
+
+    # Set up logging. https://flask.palletsprojects.com/en/1.1.x/logging/
+    dictConfig({
+        'version': 1,
+        'formatters': {'default': {
+            'format': '[%(asctime)s] %(levelname)s in %(module)s: %(message)s',
+        }},
+        'handlers': {'wsgi': {
+            'class': 'logging.StreamHandler',
+            'stream': 'ext://sys.stdout',
+            'formatter': 'default'
+        }},
+        'root': {
+            'level': 'INFO',
+            'handlers': ['wsgi']
+        }
+    })
+
     app = Flask(__name__, instance_path=instance)
 
     # The following line may be uncommented, and the corresponding

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   app-prod: &app-prod
     container_name: cb-app
     image: cb-app-prod
-    restart: always
+    restart: unless-stopped
     profiles: ["prod"]
     build:
       context: .
@@ -29,7 +29,7 @@ services:
       --error-logfile '/logs/gunicorn-error.log'"
     volumes:
       - .:/coloringbook:rw
-      - cb-logs:/logs
+      - ./logs/cb:/logs
     ports:
       - 3000:5000
 
@@ -49,7 +49,7 @@ services:
     image: mysql:5.7
     container_name: cb-db
     env_file: .env
-    restart: always
+    restart: unless-stopped
     command: --default-authentication-plugin=mysql_native_password
     environment:
       MYSQL_DATABASE: ${DB_DB}
@@ -68,6 +68,12 @@ services:
   redis:
     container_name: cb-redis
     image: redis:6.2
+    restart: unless-stopped
+    volumes:
+        - ./redis.conf:/usr/local/etc/redis/redis.conf
+        - ./redis-entrypoint.sh:/usr/local/bin/entrypoint.sh
+        - ./logs/redis:/logs/redis
+    entrypoint: ["sh", "/usr/local/bin/entrypoint.sh"]
 
   worker-prod: &worker-prod
     build: .
@@ -75,6 +81,7 @@ services:
     image: cb-worker-prod
     profiles: ["prod"]
     command: celery -A make_celery worker --uid=nobody --gid=nogroup
+    restart: unless-stopped
     environment: &worker-env
       FLASK_DEBUG: 0
       APP_SETTINGS: project.server.config.DevelopmentConfig
@@ -97,6 +104,7 @@ services:
     <<: *worker-prod
     image: cb-worker-dev
     profiles: ["dev"]
+    restart: no
     command: celery -A make_celery worker --loglevel=info --uid=nobody --gid=nogroup
     environment:
         <<: *worker-env
@@ -104,5 +112,4 @@ services:
 
 volumes:
   sql-db:
-  cb-logs:
 

--- a/redis-entrypoint.sh
+++ b/redis-entrypoint.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+# Create the log files
+mkdir -p /logs/redis
+touch /logs/redis/redis.log
+chmod -R 644 /logs
+
+# Start Redis with the provided configuration file
+exec redis-server /usr/local/etc/redis/redis.conf

--- a/redis.conf
+++ b/redis.conf
@@ -1,0 +1,3 @@
+bind 0.0.0.0
+loglevel notice
+logfile "/logs/redis/redis.log"


### PR DESCRIPTION
This PR fixes a bug reported by the researchers.

Apparently, the containers hosting Redis and the Celery worker went down on the production and acceptation servers. As a result, the application was not able to send emails and kept looking for / rebooting workers. It never sent an acknowledgement to the frontend to let it know that the results had been written to the DB, so the frontend kept resubmitting the results. As a result, the same results were written to the DB many times over, resulting in thousands of identical rows (and no emails being sent).

The issue can be reproduced by starting the application, shutting down the `cb-redis` and `cb-worker` containers and completing a survey with an email address.

This PR suggests the following changes:
- The production containers (app, db, redis, worker) have an `restart: unless-stopped` policy so the containers do not stay down if they crash in the future.
- The application will check whether Redis is available. Regardless of the outcome, the frontend is notified about the successful saving of the survey results. If Redis is unavailable, the application will not attempt to send an email and will instead emit a warning log message.
- Logs for the Gunicorn application and the Redis container are now collected outside of the container (in `./logs`). In the current version, they are put somewhere deep in `/var/lib/docker/volumes/...` where we are unable to reach them without the help of the backoffice. This should make it easier to spot these errors in the future. This setup requires a `redis.conf` configuration file.
- Application logs (with `current_app.logger`) currently do not show up in the container logs. I have added a `dictConfig()` to configure the Flask logger, following the documentation online.