### PR TITLE
Fix/action without area

### DIFF
--- a/coloringbook/mail/utilities.py
+++ b/coloringbook/mail/utilities.py
@@ -8,10 +8,10 @@ from flask_mail import Message
 import datetime as dt
 
 from coloringbook.utilities import (
-    fills_from_json,
+    actions_from_json,
     subject_from_json,
     get_survey_pages,
-    evaluate_page_fills
+    evaluate_page_actions
 )
 
 def create_survey_results_csv(survey_results):
@@ -196,8 +196,8 @@ def collect_csv_data(survey, survey_data):
         results = datum["results"]
         evaluations = []
         for page, result in zip(pages, results):
-            fills = fills_from_json(survey, page, subject, result)
-            evaluations.append(evaluate_page_fills(fills, page))
+            actions = actions_from_json(survey, page, subject, result)
+            evaluations.append(evaluate_page_actions(actions, page))
 
         # The amount of evaluations is equal to the amount of pages in the survey.
         total_pages = len(pages)

--- a/coloringbook/static/coloringbook.js
+++ b/coloringbook/static/coloringbook.js
@@ -2,7 +2,7 @@
 	(c) 2014-2023 Research Software Lab, Centre for Digital Humanities, Utrecht University
 	Licensed under the EUPL-1.2 or later. You may obtain a copy of the license at
 	https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12.
-	
+
 	It is helpful to think of this script as an event-driven state machine.
 */
 
@@ -183,7 +183,6 @@ var TransferFsm = machina.Fsm.extend({
 		if (response === 'Error') {
 			// The data were somehow invalid, but still safely stored
 			// on the server.
-			console.log('if error');
 			this.emit('uploadError');
 			this.errors = true;
 		}
@@ -327,8 +326,6 @@ function init_application() {
 	});
 	init_controls();
 	create_swatches(colors);
-	console.log(base);
-	
 	// The part below retrieves the data about the coloring pages.
 	$.ajax({
 		type: 'GET',
@@ -516,7 +513,6 @@ function refreshBufferbox() {
 
 // Make it visible to the user that the server emitted at least one error.
 function showError() {
-	console.log('showError');
 	$('#error_indicator').text('!');
 	$('#error_status').text('yes (notify maintainer)');
 	transferFsm.off('uploadError', showError);
@@ -555,7 +551,6 @@ function add_coloring_book_events() {
 // Passing an SVG to resume signals that the page start is a
 // resumption, otherwise it is a new page.
 function start_page(resumed) {
-	console.log('start_page', !!resumed);
 	page = pages[pagenum];
 	$('#sentence').html(page.text).show();
 	first_command = last_command = null;
@@ -584,7 +579,6 @@ function play_sound() {
 // Initializes the clock for coloring actions if the page is new.
 // For resumed images, preparations have been done already.
 function start_image(resumed) {
-	console.log('start_image', !!resumed);
 	var image = $('#coloring_book_image');
 	image.empty();
 	if (resumed) {
@@ -597,7 +591,6 @@ function start_image(resumed) {
 	$('#controls').show();
 	add_coloring_book_events();
 	if (! resumed) page_onset = $.now();
-	console.log(page_onset);
 }
 
 // Serialize data and do some cleanup after the subject is done
@@ -606,7 +599,6 @@ function start_image(resumed) {
 // If `prehistory` is defined, it should be an array of serialized
 // commands. Use this if the current page was a resumption.
 function end_page(prehistory) {
-	console.log('end_page', !!prehistory);
 	$('#speaker-icon').hide();
 	$('#controls').hide();
 	$('#sentence').hide();

--- a/coloringbook/views.py
+++ b/coloringbook/views.py
@@ -101,11 +101,19 @@ def submit(survey_name):
         return 'Error'
     if all(map(partial(store_subject_data, survey), data)):
         if survey.email_address:
-            send_email(
-                recipient=survey.email_address,
-                survey_data=data,
-                survey=survey
-            )
+            try:
+                send_email(
+                    recipient=survey.email_address,
+                    survey_data=data,
+                    survey=survey
+                )
+            except Exception as e:
+                current_app.logger.error(
+                    'Email sending failed for survey "{}".\n{}'.format(
+                        survey_name,
+                        traceback.format_exc(),
+                    )
+                )
         return 'Success'
     else:
         return 'Error'

--- a/coloringbook/views.py
+++ b/coloringbook/views.py
@@ -20,7 +20,7 @@ from flask import Blueprint, render_template, request, json, abort, jsonify, sen
 from .models import Survey, SurveySubject, db
 
 from .mail.utilities import send_email
-from .utilities import fills_from_json, subject_from_json, get_survey_pages
+from .utilities import actions_from_json, subject_from_json, get_survey_pages
 
 
 site = Blueprint('site', __name__)
@@ -123,7 +123,7 @@ def store_subject_data(survey, data):
         assert len(pages) == len(results)
         for pagenum, (page, result) in enumerate(zip(pages, results)):
             try:
-                s.add_all(fills_from_json(survey, page, subject, result))
+                s.add_all(actions_from_json(survey, page, subject, result))
             except:
                 current_app.logger.error(
                     'Next exception thrown on page {}.'.format(pagenum),

--- a/migrations/versions/3a2ef2e83801_add_the_back_button.py
+++ b/migrations/versions/3a2ef2e83801_add_the_back_button.py
@@ -19,7 +19,7 @@ def upgrade():
         'page_back_button',
         sa.String(length=30),
         nullable=False,
-        server_default='',
+        server_default='Terug',
     ))
 
 


### PR DESCRIPTION
The researchers reported a flashing blue/purple cog wheel icon and emails not being sent.

On further inspection the culprit was the function that checks the survey results and prepares the CSV file that is sent out via email. When writing it, I simply assumed that all actions returned from a survey would be Fills, but there are also actions of the type 'resume', which are created when users press the 'Back' button to go back to a previous Page.

This particular case escaped me because I did not have the 'Back' button in my interface. The default value for the text on this button is "", so the button is not added to the DOM if you are working with a vanilla database. I have added a default text to the DB migration so future developers working with a clean DB will always see the button.

On a separate note, I've taken the liberty to remove a couple of `console.log()`s in one commit. This commit can be left out if so desired.