### PR TITLE
Feature: handle multiple email addresses

### DIFF
--- a/coloringbook/admin/views.py
+++ b/coloringbook/admin/views.py
@@ -323,7 +323,7 @@ class SurveyView(ModelView):
     column_descriptions = {
         'name': 'Used for your reference and for generating the survey URL.',
         'title': 'Shown on the first page of the survey and in the window title.',
-        'email_address': 'Used to send a notification when a survey is completed and uploaded.',
+        'email_address': 'Used to send a notification when a survey is completed and uploaded. Add multiple addresses separated by semicolons.',
     }
 
     @action('duplicate', 'Duplicate')

--- a/coloringbook/views.py
+++ b/coloringbook/views.py
@@ -103,7 +103,6 @@ def submit(survey_name):
         if survey.email_address:
             try:
                 send_email(
-                    recipient=survey.email_address,
                     survey_data=data,
                     survey=survey
                 )


### PR DESCRIPTION
The researchers requested that a copy of every outgoing email be sent to their general CB email address and to the email address of one of the researchers who is currently doing an internship.

This PR enables users to add multiple email addresses to the `survey.email_address` field. Individual emails are then sent to each address.

This branch has been deployed to the test server, in case you want to try it out.